### PR TITLE
Perform basic installation and secure install directory

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 glpi_version: 9.4.5
 glpi_version_package: glpi-9.4.5.tgz
 
+glpi_perform_install: false
 glpi_update: false
 glpi_download_url: "https://github.com/glpi-project/glpi/releases/download/{{ glpi_version }}/{{ glpi_version_package }}"
 

--- a/files/glpi/install/.htaccess
+++ b/files/glpi/install/.htaccess
@@ -1,0 +1,10 @@
+<IfModule mod_authz_core.c>
+    Require local
+</IfModule>
+<IfModule !mod_authz_core.c>
+    order deny, allow
+    deny from all
+    allow from 127.0.0.1
+    allow from ::1
+</IfModule>
+ErrorDocument 403 "<p><b>Restricted area.</b><br />Only local access allowed.<br />Check your configuration or contact your administrator.</p>"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,44 @@
     validate_certs: false
   when: not glpiinstalled.stat.exists or glpi_update
 
+- name: Perform basic installation (this take a while...)
+  command:
+    chdir: "{{ glpi_install_path }}/glpi"
+    cmd: "php bin/console -n db:install -H {{ glpi_db_host }} -P {{ glpi_db_port }} -d {{ glpi_db_name }} -u {{ glpi_db_user }} -p {{ glpi_db_password }}"
+  when: ( not glpiinstalled.stat.exists or glpi_update ) and glpi_perform_install
+  register: glpi_installation
+
+- name: Set permisions to files directory
+  file:
+    path: "{{ glpi_install_path }}/glpi/files"
+    recurse: yes
+    owner: "{{ glpi_web_owner }}"
+    group: "{{ glpi_web_group }}"
+  when: not glpiinstalled.stat.exists or glpi_update
+
+- name: Set permisions to config directory
+  file:
+    path: "{{ glpi_install_path }}/glpi/config"
+    recurse: yes
+    owner: "{{ glpi_web_owner }}"
+    group: "{{ glpi_web_group }}"
+  when: not glpiinstalled.stat.exists or glpi_update
+
+- name: Secure installation directory
+  copy:
+    src: "glpi/install/.htaccess"
+    dest: "{{ glpi_install_path }}/glpi/install/.htaccess"
+    owner: "{{ glpi_web_owner }}"
+    group: "{{ glpi_web_group }}"
+    mode: 0440
+  when: glpi_installation.changed
+
+- name: Remove install/install.php file
+  file:
+    path: "{{ glpi_install_path }}/glpi/install/install.php"
+    state: absent
+  when: glpi_installation.changed
+
 - name: Download plugins
   get_url:
     url: "{{ item }}"


### PR DESCRIPTION
The base project downloads glpi package, also download and unarchive plug-ins and put them on correct directory. But the installation process needs to be manual. These new feature include the installation process (configurable by `glpi_perform_install` variable), set the [recomended directory permissions](https://glpi-install.readthedocs.io/en/latest/install/index.html#files-and-directories-locations) and [secure the installation directory](https://glpi-install.readthedocs.io/en/latest/install/index.html#post-installation).

---

El proyecto de base descarga el comprimido del GLPI de la página del proyecto, lo descomprime, también descarga y descomprime los plugins en los directorios correspondientes pero la instalación propiamente dicha de la aplicación queda para realizar en pasos manuales. Con estas modificaciones, además de todo lo anterior, realiza una instalación básica de la aplicación, configura los [permisos recomendados](https://glpi-install.readthedocs.io/en/latest/install/index.html#files-and-directories-locations) y [asegura el directorio de instalación](https://glpi-install.readthedocs.io/en/latest/install/index.html#post-installation). Este agregado es a su vez opcional, configurable en la variable `glpi_perform_install`